### PR TITLE
Updated the whitelisted hosts

### DIFF
--- a/netlify/functions/signer.js
+++ b/netlify/functions/signer.js
@@ -233,7 +233,7 @@ const handler = async (event) => {
 
   const body = JSON.parse(event.body);
 
-  let hostname_whitelist = ['globalcoinresearch.com', 'gcr.supremeonline.solutions'];
+  let hostname_whitelist = ['globalcoinresearch.com'];
 
   if (
     event.httpMethod == "POST"

--- a/netlify/functions/signerTest.js
+++ b/netlify/functions/signerTest.js
@@ -233,7 +233,7 @@ const handler = async (event) => {
 
   const body = JSON.parse(event.body);
 
-  let hostname_whitelist = ['globalcoinresearch.com', 'gcr.supremeonline.solutions'];
+  let hostname_whitelist = ['globalcoinresearch.and', 'gcr.supremeonline.solutions'];
 
   if (
     event.httpMethod == "POST"


### PR DESCRIPTION
The Ropsten test net should be the only networks available for the development and staging environments.
The Mainnet should be the only network available for the live site.